### PR TITLE
fix(nominatim): adiciona cabeçalho User-Agent para evitar bloqueio de requisições

### DIFF
--- a/api/core/integrations/nominatim/nominatim.py
+++ b/api/core/integrations/nominatim/nominatim.py
@@ -20,26 +20,34 @@ class Nominatim:
     def __init__(self, city:str, state:str, country_iso:str, contact_email:str, bbox_bound:dict=None)->None:
 
         
-        self.build_query = QueryBuilder(city, state, country_iso, 
+        self.build_query = QueryBuilder(city, state, country_iso,
                                         contact_email, bbox_bound)
 
         self.session = Session()
         self.add_language_headers()
+        self.add_user_agent_header(contact_email)
 
-        self.base_url = self.build_base_url()    
-        
+        self.base_url = self.build_base_url()
+
     def build_base_url(self)->str:
 
         return f'https://{self.host}/{self.endpoint}'
-        
-    
+
+
     def add_language_headers(self):
-        
+
         #tem que colocar esse header se nao ele muda a language da
         #resposta da API com base no reverse location search do IP
         #o que faria o codigo quebrar
 
         self.session.headers.update({'Accept-Language' : 'en-US'})
+
+    def add_user_agent_header(self, contact_email:str):
+
+        #Nominatim bloqueia User-Agents genéricos de bibliotecas HTTP (retorna 403).
+        #https://operations.osmfoundation.org/policies/nominatim/
+
+        self.session.headers.update({'User-Agent': f'smae-backend-geoloc ({contact_email})'})
 
     @json_decode_error_handling
     def address_request(self, address:str)->dict:

--- a/api/core/integrations/nominatim/nominatim_cep.py
+++ b/api/core/integrations/nominatim/nominatim_cep.py
@@ -20,26 +20,34 @@ class NominatimCep:
     def __init__(self, city:str, state:str, country_iso:str, contact_email:str, bbox_bound:dict=None)->None:
 
         
-        self.build_query = CepQueryBuilder(city, state, country_iso, 
+        self.build_query = CepQueryBuilder(city, state, country_iso,
                                         contact_email, bbox_bound)
 
         self.session = Session()
         self.add_language_headers()
+        self.add_user_agent_header(contact_email)
 
         self.base_url = self.build_base_url()
-        
+
     def build_base_url(self)->str:
 
         return f'https://{self.host}/{self.endpoint}'
-        
-    
+
+
     def add_language_headers(self):
-        
+
         #tem que colocar esse header se nao ele muda a language da
         #resposta da API com base no reverse location search do IP
         #o que faria o codigo quebrar
 
         self.session.headers.update({'Accept-Language' : 'en-US'})
+
+    def add_user_agent_header(self, contact_email:str):
+
+        #Nominatim bloqueia User-Agents genéricos de bibliotecas HTTP (retorna 403).
+        #https://operations.osmfoundation.org/policies/nominatim/
+
+        self.session.headers.update({'User-Agent': f'smae-backend-geoloc ({contact_email})'})
 
     @json_decode_error_handling
     def cep_request(self, cep:str)->dict:

--- a/api/core/integrations/nominatim/nominatim_reverse_geocode.py
+++ b/api/core/integrations/nominatim/nominatim_reverse_geocode.py
@@ -16,18 +16,26 @@ class ReverseGeocoding:
         self.session = Session()
         self.build_query = ReverseQueryBuilder(contact_email)
         self.add_language_headers()
+        self.add_user_agent_header(contact_email)
 
     def build_base_url(self, host:str, endpoint:str)->str:
 
         return f'https://{host}/{endpoint}'
-    
+
     def add_language_headers(self):
-        
+
         #tem que colocar esse header se nao ele muda a language da
         #resposta da API com base no reverse location search do IP
         #o que faria o codigo quebrar
 
         self.session.headers.update({'Accept-Language' : 'en-US'})
+
+    def add_user_agent_header(self, contact_email:str):
+
+        #Nominatim bloqueia User-Agents genéricos de bibliotecas HTTP (retorna 403).
+        #https://operations.osmfoundation.org/policies/nominatim/
+
+        self.session.headers.update({'User-Agent': f'smae-backend-geoloc ({contact_email})'})
     
 
     @json_decode_error_handling


### PR DESCRIPTION
## Resumo

Adiciona o cabeçalho `User-Agent` nas requisições ao serviço Nominatim, utilizando o e-mail de contato.

O Nominatim bloqueia requisições que usam User-Agents genéricos de bibliotecas HTTP (conforme a política de uso do serviço). Este ajuste evita esses bloqueios identificando corretamente o cliente.

## Alterações
- `a5b345e` fix(nominatim): adiciona cabeçalho User-Agent para evitar bloqueio de requisições